### PR TITLE
ramips: fix RT-AC57U button level

### DIFF
--- a/target/linux/ramips/dts/RT-AC57U.dts
+++ b/target/linux/ramips/dts/RT-AC57U.dts
@@ -47,7 +47,7 @@
 
 		wps {
 			label = "wps";
-			gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 			debounce-interval = <60>;
 		};


### PR DESCRIPTION
Both buttons on the RT-AC57U are active-low. Fix the GPIO flag for the
WPS cutton to fix button behavior.

Signed-off-by: David Bauer <mail@david-bauer.net>
(cherry picked from commit 535b0c70b1c466733b009144f81f5207f1ecd311)